### PR TITLE
Added rhsso instances and operators

### DIFF
--- a/instances/rhsso-instance/base/kustomization.yaml
+++ b/instances/rhsso-instance/base/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: sso
+
+resources:
+  - sso.yaml
+  - rbac.yaml

--- a/instances/rhsso-instance/base/rbac.yaml
+++ b/instances/rhsso-instance/base/rbac.yaml
@@ -1,0 +1,28 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: keycloak
+rules:
+  - apiGroups:
+      - keycloak.org
+    resources:
+      - keycloaks
+    verbs:
+      - get
+      - list
+      - patch
+      - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: keycloak
+  namespace: sso
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: keycloak
+subjects:
+  - kind: ServiceAccount
+    name: openshift-gitops-cntk-argocd-application-controller
+    namespace: openshift-gitops

--- a/instances/rhsso-instance/base/sso.yaml
+++ b/instances/rhsso-instance/base/sso.yaml
@@ -1,0 +1,13 @@
+apiVersion: keycloak.org/v1alpha1
+kind: Keycloak
+metadata:
+  name: rhsso
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  labels:
+    app: sso
+spec:
+  instances: 1
+  profile: RHSSO
+  externalAccess:
+    enabled: true

--- a/instances/rhsso-instance/kustomization.yaml
+++ b/instances/rhsso-instance/kustomization.yaml
@@ -1,0 +1,5 @@
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+
+bases:
+  - overlays/default

--- a/instances/rhsso-instance/overlays/crc/client-secret.yaml
+++ b/instances/rhsso-instance/overlays/crc/client-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+data:
+  clientSecret: NWU5MzI2ZWUtYWM4ZC00MGJmLTkwNjAtZTkxZGJlOWQ5MDAw
+kind: Secret
+metadata:
+  name: openid-client-secret
+  namespace: openshift-config
+type: Opaque

--- a/instances/rhsso-instance/overlays/crc/kustomization.yaml
+++ b/instances/rhsso-instance/overlays/crc/kustomization.yaml
@@ -1,0 +1,28 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - ../../base
+#  - ../../base/openshift-authentication
+
+resources:
+  - oauth-rhsso-openid.yaml
+  - openshift-user.yaml
+  - rhsso-default-cluster-admin-user.yaml
+  - client-secret.yaml
+  - openshift-realm.yaml
+  - openshift-client.yaml
+
+patchesJson6902:
+  - target:
+      group: keycloak.org
+      version: v1alpha1
+      kind: KeycloakClient
+      name: openshift-client
+    path: patch-redirect-uri.yaml
+  - target:
+      group: config.openshift.io
+      version: v1
+      kind: OAuth
+      name: cluster
+    path: patch-issuer.yaml

--- a/instances/rhsso-instance/overlays/crc/oauth-rhsso-openid.yaml
+++ b/instances/rhsso-instance/overlays/crc/oauth-rhsso-openid.yaml
@@ -1,0 +1,38 @@
+apiVersion: config.openshift.io/v1
+kind: OAuth
+metadata:
+  name: cluster
+spec:
+  identityProviders:
+    - name: rhsso
+      mappingMethod: claim
+      type: OpenID
+      openID:
+        clientID: openshift
+        clientSecret:
+          name: openid-client-secret
+        ca:
+          name: openidcacrt
+        extraScopes:
+          - email
+          - profile
+        extraAuthorizeParameters:
+          include_granted_scopes: "true"
+        claims:
+          preferredUsername:
+            - preferred_username
+            - email
+          name:
+            - nickname
+            - given_name
+            - name
+          email:
+            - custom_email_claim
+            - email
+        issuer: https://keycloak.example.com/auth/realms/openshift
+    - htpasswd:
+        fileData:
+          name: htpasswd-secret
+      mappingMethod: claim
+      name: htpasswd_provider
+      type: HTPasswd

--- a/instances/rhsso-instance/overlays/crc/openshift-client.yaml
+++ b/instances/rhsso-instance/overlays/crc/openshift-client.yaml
@@ -1,0 +1,21 @@
+apiVersion: keycloak.org/v1alpha1
+kind: KeycloakClient
+metadata:
+  name: openshift-client
+  labels:
+    app: sso
+spec:
+  realmSelector:
+    matchLabels:
+      app: openshift
+  client:
+    clientId: openshift
+    realm": "openshift"
+    secret: 5e9326ee-ac8d-40bf-9060-e91dbe9d9000
+    clientAuthenticatorType: client-secret
+    consentRequired: false
+    standardFlowEnabled: true
+    implicitFlowEnabled: false
+    directAccessGrantsEnabled: true
+    redirectUris:
+      - "https://keycloak.example.com/auth/realms/master/protocol/openid-connect/token"

--- a/instances/rhsso-instance/overlays/crc/openshift-realm.yaml
+++ b/instances/rhsso-instance/overlays/crc/openshift-realm.yaml
@@ -1,0 +1,16 @@
+apiVersion: keycloak.org/v1alpha1
+kind: KeycloakRealm
+metadata:
+  labels:
+    app: openshift
+  name: openshift-realm
+  namespace: sso
+spec:
+  realm:
+    id: openshift
+    realm: openshift
+    enabled: true
+    displayName: Openshift Authentication Realm
+  instanceSelector:
+    matchLabels:
+      app: sso

--- a/instances/rhsso-instance/overlays/crc/openshift-user.yaml
+++ b/instances/rhsso-instance/overlays/crc/openshift-user.yaml
@@ -1,0 +1,22 @@
+apiVersion: keycloak.org/v1alpha1
+kind: KeycloakUser
+metadata:
+  name: ocpadmin-user
+  labels:
+    app: sso
+  namespace: sso
+spec:
+  user:
+    username: ocpadmin
+    firstName: John
+    lastName: Doe
+    email: user@example.com
+    enabled: true
+    emailVerified: false
+    credentials:
+      - temporary: false
+        type: password
+        value: password
+  realmSelector:
+    matchLabels:
+      app: openshift

--- a/instances/rhsso-instance/overlays/crc/patch-issuer.yaml
+++ b/instances/rhsso-instance/overlays/crc/patch-issuer.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/identityProviders/0/openID/issuer
+  value: https://keycloak-sso.apps-crc.testing/auth/realms/openshift

--- a/instances/rhsso-instance/overlays/crc/patch-redirect-uri.yaml
+++ b/instances/rhsso-instance/overlays/crc/patch-redirect-uri.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/client/redirectUris
+  value: ["https://oauth-openshift.apps-crc.testing/oauth2callback/rhsso"]

--- a/instances/rhsso-instance/overlays/crc/rhsso-default-cluster-admin-user.yaml
+++ b/instances/rhsso-instance/overlays/crc/rhsso-default-cluster-admin-user.yaml
@@ -1,0 +1,11 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rhsso-default-cluster-admin-user
+subjects:
+  - kind: User
+    name: ocpadmin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin

--- a/instances/rhsso-instance/overlays/default/kustomization.yaml
+++ b/instances/rhsso-instance/overlays/default/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: sso
+
+bases:
+  - ../../base

--- a/instances/rhsso-instance/overlays/rhpds/client-secret.yaml
+++ b/instances/rhsso-instance/overlays/rhpds/client-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+data:
+  clientSecret: NWU5MzI2ZWUtYWM4ZC00MGJmLTkwNjAtZTkxZGJlOWQ5MDAw
+kind: Secret
+metadata:
+  name: openid-client-secret
+  namespace: openshift-config
+type: Opaque

--- a/instances/rhsso-instance/overlays/rhpds/kustomization.yaml
+++ b/instances/rhsso-instance/overlays/rhpds/kustomization.yaml
@@ -1,0 +1,25 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - ../../base
+
+resources:
+  - oauth-rhsso-openid.yaml
+  - client-secret.yaml
+  - openshift-realm.yaml
+  - openshift-client.yaml
+
+patchesJson6902:
+  - target:
+      group: keycloak.org
+      version: v1alpha1
+      kind: KeycloakClient
+      name: openshift-client
+    path: patch-redirect-uri.yaml
+  - target:
+      group: config.openshift.io
+      version: v1
+      kind: OAuth
+      name: cluster
+    path: patch-issuer.yaml

--- a/instances/rhsso-instance/overlays/rhpds/oauth-rhsso-openid.yaml
+++ b/instances/rhsso-instance/overlays/rhpds/oauth-rhsso-openid.yaml
@@ -1,0 +1,38 @@
+apiVersion: config.openshift.io/v1
+kind: OAuth
+metadata:
+  name: cluster
+spec:
+  identityProviders:
+    - name: rhsso
+      mappingMethod: claim
+      type: OpenID
+      openID:
+        clientID: openshift
+        clientSecret:
+          name: openid-client-secret
+        ca:
+          name: openidcacrt
+        extraScopes:
+          - email
+          - profile
+        extraAuthorizeParameters:
+          include_granted_scopes: "true"
+        claims:
+          preferredUsername:
+            - preferred_username
+            - email
+          name:
+            - nickname
+            - given_name
+            - name
+          email:
+            - custom_email_claim
+            - email
+        issuer: https://keycloak.example.com/auth/realms/openshift
+    - htpasswd:
+        fileData:
+          name: htpasswd-secret
+      mappingMethod: claim
+      name: htpasswd_provider
+      type: HTPasswd

--- a/instances/rhsso-instance/overlays/rhpds/openshift-client.yaml
+++ b/instances/rhsso-instance/overlays/rhpds/openshift-client.yaml
@@ -1,0 +1,21 @@
+apiVersion: keycloak.org/v1alpha1
+kind: KeycloakClient
+metadata:
+  name: openshift-client
+  labels:
+    app: sso
+spec:
+  realmSelector:
+    matchLabels:
+      app: openshift
+  client:
+    clientId: openshift
+    realm": "openshift"
+    secret: 5e9326ee-ac8d-40bf-9060-e91dbe9d9000
+    clientAuthenticatorType: client-secret
+    consentRequired: false
+    standardFlowEnabled: true
+    implicitFlowEnabled: false
+    directAccessGrantsEnabled: true
+    redirectUris:
+      - "https://keycloak.example.com/auth/realms/master/protocol/openid-connect/token"

--- a/instances/rhsso-instance/overlays/rhpds/openshift-realm.yaml
+++ b/instances/rhsso-instance/overlays/rhpds/openshift-realm.yaml
@@ -1,0 +1,16 @@
+apiVersion: keycloak.org/v1alpha1
+kind: KeycloakRealm
+metadata:
+  labels:
+    app: openshift
+  name: openshift-realm
+  namespace: sso
+spec:
+  realm:
+    id: openshift
+    realm: openshift
+    enabled: true
+    displayName: Openshift Authentication Realm
+  instanceSelector:
+    matchLabels:
+      app: sso

--- a/instances/rhsso-instance/overlays/rhpds/patch-issuer.yaml
+++ b/instances/rhsso-instance/overlays/rhpds/patch-issuer.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/identityProviders/0/openID/issuer
+  value: https://keycloak-sso.apps.cluster-c641.c641.example.opentlc.com/auth/realms/openshift

--- a/instances/rhsso-instance/overlays/rhpds/patch-redirect-uri.yaml
+++ b/instances/rhsso-instance/overlays/rhpds/patch-redirect-uri.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/client/redirectUris
+  value: ["https://oauth-openshift.apps.cluster-c641.c641.example.opentlc.com/oauth2callback/rhsso"]

--- a/operators/rhsso-operator/base/approval-and-cert-job.yaml
+++ b/operators/rhsso-operator/base/approval-and-cert-job.yaml
@@ -1,0 +1,71 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: installplan-approver
+  namespace: sso
+spec:
+  template:
+    spec:
+      containers:
+        - image: registry.redhat.io/openshift4/ose-cli:v4.4
+          env:
+            - name: APPROVAL_NAMESPACES
+              value: "sso"
+            - name: GENERATE_OPENID_CERT
+              value: 'false'
+          command:
+            - /bin/bash
+            - -c
+            - |
+              export HOME=/tmp/approver
+
+              echo "Approving RH-SSO operator install.  Waiting a few seconds to make sure the InstallPlan gets created first."
+              sleep 20
+              for subscription in `oc get sub -n sso -o name`
+              do
+                echo "Subs: ${subscription}"
+                while [[ "$(oc get $subscription -n sso -o jsonpath='{ .status.currentCSV }')" == "" ]]
+                do
+                    sleep 2;
+                done
+                desiredcsv=$(oc get $subscription -n sso -o jsonpath='{ .status.currentCSV }')
+                echo "Desired csv: $desiredcsv"
+
+                until [ "$(oc get installplan -n sso -o jsonpath="{.items[?(@.spec.clusterServiceVersionNames[*] == \"$desiredcsv\")].metadata.name}")" != "" ]; do sleep 2; done
+
+                installplan=$(oc get installplan -n sso -o jsonpath="{.items[?(@.spec.clusterServiceVersionNames[*] == \"$desiredcsv\")].metadata.name}")
+
+                if [ "`oc get installplan $installplan -n sso -o jsonpath="{.spec.approved}"`" == "false" ]; then
+
+                  echo "Approving Subscription $subscription with install plan $installplan"
+
+                  oc patch -n sso installplan $installplan --type=json -p='[{"op":"replace","path": "/spec/approved", "value": true}]'
+
+                else
+                  echo "Install Plan '$installplan' already approved"
+                fi
+              done
+
+              if [ "$GENERATE_OPENID_CERT" == true ] ; then
+
+                  echo "GENERATE_OPENID_CERT set to 'true'.  Create a ConfigMap named openidcrt in the openshift-config project."
+
+                  # Get name of certs secret.  It can be router-certs or router-certs-default.
+                  CERT_SECRET=$(oc get secrets -n openshift-ingress | grep 'router-certs\|ingress-certs\|-ingress' | cut -d ' ' -f1)
+
+                  tlscert=`oc get secrets/$CERT_SECRET -o jsonpath={.data.'tls\.crt'} -n openshift-ingress | base64 --decode`
+                  oc create configmap openidcacrt --from-literal ca.crt="$tlscert" -n openshift-config
+
+              else
+
+                  echo "GENERATE_OPENID_CERT set to 'false'.  Will not create an openidcrt ConfigMap in the openshift-config namespace."
+
+              fi
+
+          imagePullPolicy: Always
+          name: installplan-approver-and-cert-secret
+      dnsPolicy: ClusterFirst
+      restartPolicy: OnFailure
+      serviceAccount: rhsso-operator-job
+      serviceAccountName: rhsso-operator-job
+      terminationGracePeriodSeconds: 30

--- a/operators/rhsso-operator/base/kustomization.yaml
+++ b/operators/rhsso-operator/base/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - rhsso-operatorgroup.yaml
+  - rhsso-subscription.yaml
+  - approval-and-cert-job.yaml
+  - serviceaccount.yaml
+  - rbac.yaml

--- a/operators/rhsso-operator/base/rbac.yaml
+++ b/operators/rhsso-operator/base/rbac.yaml
@@ -1,0 +1,65 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: installplan-approver
+rules:
+  - apiGroups:
+      - operators.coreos.com
+    resources:
+      - installplans
+      - subscriptions
+    verbs:
+      - get
+      - list
+      - patch
+  - apiGroups:
+      - apps.open-cluster-management.io
+    resources:
+      - installplans
+      - subscriptions
+    verbs:
+      - get
+      - list
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rhsso-cert-secret-creator
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - secrets
+    verbs:
+      - get
+      - list
+      - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: installplan-approvers
+  namespace: sso
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: installplan-approver
+subjects:
+  - kind: ServiceAccount
+    name: rhsso-operator-job
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rhsso-cert-secret-creators
+  namespace: sso
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rhsso-cert-secret-creator
+subjects:
+  - kind: ServiceAccount
+    name: rhsso-operator-job
+    namespace: sso

--- a/operators/rhsso-operator/base/rhsso-operatorgroup.yaml
+++ b/operators/rhsso-operator/base/rhsso-operatorgroup.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  annotations:
+    olm.providedAPIs: Keycloak.v1alpha1.keycloak.org,KeycloakBackup.v1alpha1.keycloak.org,KeycloakClient.v1alpha1.keycloak.org,KeycloakRealm.v1alpha1.keycloak.org,KeycloakUser.v1alpha1.keycloak.org
+  generateName: sso-
+  name: sso
+spec:
+  targetNamespaces:
+    - sso

--- a/operators/rhsso-operator/base/rhsso-subscription.yaml
+++ b/operators/rhsso-operator/base/rhsso-subscription.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: rhsso-operator
+spec:
+  channel: alpha
+  installPlanApproval: Manual
+  name: rhsso-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/operators/rhsso-operator/base/serviceaccount.yaml
+++ b/operators/rhsso-operator/base/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rhsso-operator-job

--- a/operators/rhsso-operator/kustomization.yaml
+++ b/operators/rhsso-operator/kustomization.yaml
@@ -1,0 +1,5 @@
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+
+bases:
+  - overlays/default

--- a/operators/rhsso-operator/overlays/default/kustomization.yaml
+++ b/operators/rhsso-operator/overlays/default/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: sso
+
+bases:
+  - ../../base
+
+patchesStrategicMerge:
+  - patch-target-namespace.yaml

--- a/operators/rhsso-operator/overlays/default/patch-target-namespace.yaml
+++ b/operators/rhsso-operator/overlays/default/patch-target-namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: sso
+spec:
+  targetNamespaces:
+    - sso


### PR DESCRIPTION
1) Fixed bugs from scritps in approve-and-cert-jobs.yaml with some small changes. The bug might come from out-of-date yaml data structure, and the script cannot find matching node in the yaml.
2) Added rbac for operator and instance to run successfully
3) added root level kustomization.yaml for the argocd to pick up