### PR TITLE
Change apiVersion of external-secrets.io

### DIFF
--- a/instances/external-secrets-instance/overlays/default/cluster-secret-store.yaml
+++ b/instances/external-secrets-instance/overlays/default/cluster-secret-store.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1alpha1
+apiVersion: external-secrets.io/v1beta1
 kind: ClusterSecretStore
 metadata:
   name: cluster


### PR DESCRIPTION
Looks they beta is used now for ClusterSecretStore. 

When alpha1 is used additional (outdated) fields are added causing the ClusterSecretStore object creation to always be in the "pending" state. See the screenshots provided below.

<img width="1390" alt="Alpha1-Pending" src="https://user-images.githubusercontent.com/21075687/183818807-ea877fab-a469-4261-8b9c-439dddb303d8.png">

<img width="725" alt="Alpha1-YAML-Fields" src="https://user-images.githubusercontent.com/21075687/183818818-8c2f23ec-7180-4f09-8bc3-6014af5bd0dc.png">

When using beta1, all is fine. Refer to the screenshot below.

<img width="1234" alt="Beta1-Ready" src="https://user-images.githubusercontent.com/21075687/183818921-63c2b131-cea9-495b-a82d-397edbee90d3.png">
