### PR TITLE
Add RHACM 2.6 Operator and make default

### DIFF
--- a/operators/openshift-acm/kustomization.yaml
+++ b/operators/openshift-acm/kustomization.yaml
@@ -2,4 +2,4 @@ kind: Kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 
 bases:
-  - overlays/release-2.5
+  - overlays/release-2.6

--- a/operators/openshift-acm/overlays/release-2.6/kustomization.yaml
+++ b/operators/openshift-acm/overlays/release-2.6/kustomization.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - ../../base
+
+patches:
+  - target:
+      kind: Subscription
+      name: advanced-cluster-management
+    patch: |-
+      - op: replace
+        path: /spec/channel
+        value: 'release-2.6'


### PR DESCRIPTION
With the release of RHACM 2.6, an update to the kustomise overlays has not only been included to make this a selectable option upon ACM deployment, but is now the default version to deploy